### PR TITLE
refactor: define modules in separate files with importApply

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         flake =
           # Put your original flake attributes here.
           let
+            inherit (inputs.flake-parts.lib) importApply;
             pkgsOverlays = {
               nixpkgs.overlays = [
                 self.overlays.default
@@ -50,93 +51,70 @@
             };
           in
           {
-            nixosModules = import ./modules;
+            nixosModules = import ./modules {
+              inherit importApply withSystem;
+              localFlake = self;
+            };
 
-            nixosConfigurations.nixo6n = nixpkgs.lib.nixosSystem {
-              specialArgs = { inherit inputs; };
-              modules = [
-                pkgsOverlays
+            nixosConfigurations =
+              let
+                mkSystem =
+                  machine: extraModules:
+                  nixpkgs.lib.nixosSystem {
+                    specialArgs = { inherit inputs; };
+                    modules = [
+                      pkgsOverlays
 
-                ./nixos/machines/o6n/configuration.nix
+                      (./. + "/nixos/machines/${machine}/configuration.nix")
 
-                home-manager.nixosModules.home-manager
-                {
-                  home-manager.useGlobalPkgs = true;
-                  home-manager.useUserPackages = true;
-                  home-manager.users.shiroki = {
-                    imports = [
-                      ./home.nix
-                      catppuccin.homeModules.catppuccin
-                    ];
+                      home-manager.nixosModules.home-manager
+                      {
+                        home-manager.useGlobalPkgs = true;
+                        home-manager.useUserPackages = true;
+                        home-manager.users.shiroki = {
+                          imports = [
+                            ./home.nix
+                            catppuccin.homeModules.catppuccin
+                          ];
+                        };
+
+                        # Optionally, use home-manager.extraSpecialArgs to pass
+                        # arguments to home.nix
+                        home-manager.extraSpecialArgs = {
+                          inherit machine;
+                        };
+                      }
+
+                      inputs.daeuniverse.nixosModules.dae
+                      inputs.daeuniverse.nixosModules.daed
+
+                      catppuccin.nixosModules.catppuccin
+                      {
+                        catppuccin.cache.enable = true;
+                      }
+                    ] ++ extraModules;
                   };
-
-                  # Optionally, use home-manager.extraSpecialArgs to pass
-                  # arguments to home.nix
-                  home-manager.extraSpecialArgs = {
-                    machine = "o6n";
-                  };
-                }
-
-                inputs.daeuniverse.nixosModules.dae
-                inputs.daeuniverse.nixosModules.daed
-
-                catppuccin.nixosModules.catppuccin
-                {
-                  catppuccin.cache.enable = true;
-                }
-
-                sops-nix.nixosModules.sops
-                {
-                  sops = {
-                    environment = {
-                      SOPS_AGE_SSH_PRIVATE_KEY_FILE = "/etc/ssh/ssh_host_ed25519_key";
+              in
+              {
+                nixo6n = mkSystem "o6n" [
+                  sops-nix.nixosModules.sops
+                  {
+                    sops = {
+                      environment = {
+                        SOPS_AGE_SSH_PRIVATE_KEY_FILE = "/etc/ssh/ssh_host_ed25519_key";
+                      };
                     };
-                  };
-                }
+                  }
+                  self.nixosModules.qbittorrent-clientblocker
+                  self.nixosModules.snell-server
+                ];
 
-                self.nixosModules.qbittorrent-clientblocker
-                self.nixosModules.snell-server
-              ];
-            };
-
-            nixosConfigurations.nixopi5 = nixpkgs.lib.nixosSystem {
-              specialArgs = { inherit inputs; };
-              modules = [
-                pkgsOverlays
-
-                ./nixos/machines/opi5/configuration.nix
-
-                home-manager.nixosModules.home-manager
-                {
-                  home-manager.useGlobalPkgs = true;
-                  home-manager.useUserPackages = true;
-                  home-manager.users.shiroki = {
-                    imports = [
-                      ./home.nix
-                      catppuccin.homeModules.catppuccin
-                    ];
-                  };
-
-                  # Optionally, use home-manager.extraSpecialArgs to pass
-                  # arguments to home.nix
-                  home-manager.extraSpecialArgs = {
-                    machine = "opi5";
-                  };
-                }
-
-                inputs.daeuniverse.nixosModules.dae
-                inputs.daeuniverse.nixosModules.daed
-
-                catppuccin.nixosModules.catppuccin
-                {
-                  catppuccin.cache.enable = true;
-                }
-
-                self.nixosModules.msd-lite
-                self.nixosModules.qbittorrent-clientblocker
-                self.nixosModules.snell-server
-              ];
-            };
+                nixopi5 = mkSystem "opi5" [
+                  self.nixosModules.msd-lite
+                  self.nixosModules.qbittorrent-clientblocker
+                  self.nixosModules.snell-server
+                ];
+              };
           };
         systems =
           # systems for which you want to build the `perSystem` attributes

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,9 +1,8 @@
+{ importApply, localFlake, withSystem }:
+
 {
-  # Add your NixOS modules here
-  #
-  # my-module = ./my-module;
-  msd-lite = ./msd-lite.nix;
-  qbittorrent-clientblocker = ./qbittorrent-clientblocker.nix;
-  snell-server = ./snell-server.nix;
-  tcp-brutal = ./tcp-brutal.nix;
+  msd-lite = importApply ./msd-lite.nix { inherit localFlake withSystem; };
+  qbittorrent-clientblocker = importApply ./qbittorrent-clientblocker.nix { inherit localFlake withSystem; };
+  snell-server = importApply ./snell-server.nix { inherit localFlake withSystem; };
+  tcp-brutal = importApply ./tcp-brutal.nix { inherit localFlake withSystem; };
 }

--- a/modules/msd-lite.nix
+++ b/modules/msd-lite.nix
@@ -1,3 +1,4 @@
+{ localFlake, withSystem }:
 {
   config,
   lib,
@@ -316,7 +317,14 @@ in
       description = "List of source profile templates (sourceProfile).";
     };
 
-    package = lib.options.mkPackageOption pkgs "msd-lite" { };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = withSystem pkgs.stdenv.hostPlatform.system (
+        { config, ... }: config.packages.msd-lite
+      );
+      defaultText = lib.literalMD "`packages.msd-lite` from the shirok1/flakes flake";
+      description = "The msd-lite package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/qbittorrent-clientblocker.nix
+++ b/modules/qbittorrent-clientblocker.nix
@@ -1,3 +1,4 @@
+{ localFlake, withSystem }:
 {
   config,
   lib,
@@ -46,12 +47,14 @@ in
       };
     };
 
-    package = lib.options.mkPackageOption pkgs "qbittorrent-clientblocker" { };
-    # package = lib.mkOption {
-    #   type = lib.types.package;
-    #   default = pkgs.qbittorrent-clientblocker;
-    #   description = "The qbittorrent-clientblocker package to use.";
-    # };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = withSystem pkgs.stdenv.hostPlatform.system (
+        { config, ... }: config.packages.qbittorrent-clientblocker
+      );
+      defaultText = lib.literalMD "`packages.qbittorrent-clientblocker` from the shirok1/flakes flake";
+      description = "The qbittorrent-clientblocker package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/snell-server.nix
+++ b/modules/snell-server.nix
@@ -1,3 +1,4 @@
+{ localFlake, withSystem }:
 {
   config,
   lib,
@@ -41,7 +42,14 @@ in
       '';
     };
 
-    package = lib.options.mkPackageOption pkgs "snell-server" { };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = withSystem pkgs.stdenv.hostPlatform.system (
+        { config, ... }: config.packages.snell-server
+      );
+      defaultText = lib.literalMD "`packages.snell-server` from the shirok1/flakes flake";
+      description = "The snell-server package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/tcp-brutal.nix
+++ b/modules/tcp-brutal.nix
@@ -1,3 +1,4 @@
+{ localFlake, withSystem }:
 {
   config,
   lib,
@@ -27,7 +28,7 @@ in
     assertions = [ ];
 
     boot.extraModulePackages = [
-      (config.boot.kernelPackages.callPackage ../_pkgs/tcp-brutal.nix { })
+      (config.boot.kernelPackages.callPackage "${localFlake}/_pkgs/tcp-brutal.nix" { })
     ];
   };
 }


### PR DESCRIPTION
Refactored the Nix flake to follow the `flake.parts` documentation for defining NixOS modules in separate files. This was done using the `importApply` pattern to inject `localFlake` and `withSystem` directly into each module. This cleanly decouples the default package configurations from the global `nixpkgs` overlay requirement. Also introduced a `mkSystem` helper in `flake.nix` to deduplicate identical NixOS system module listings.

---
*PR created automatically by Jules for task [1834083815202542588](https://jules.google.com/task/1834083815202542588) started by @shirok1*